### PR TITLE
Fix/test tz

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -153,9 +153,10 @@ appserver: $(builddir)/src/appserver.boot
 outgoingproxy: $(builddir)/src/outgoingproxy.boot
 	$(create_start_script)
 
+test: TZ = CET
 test:
 	echo "Making test in src/"; \
-	(cd src/ && $(MAKE) test) || exit 1
+	(cd src/ && $(MAKE) test TZ=$(TZ)) || exit 1
 
 covertest:
 	echo "Making covertest in src/"; \


### PR DESCRIPTION
Hello Fredrik,
this small time zone fix to the Makefile makes it possible to test without first setting the time zone. For example when building in a Debian/Ubuntu pbuilder.

/Mikael
