### PR TITLE
configure/make errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_REVISION($Revision$)
 AC_PREREQ(2.64)
 AC_INIT(YXA, 1.0-current, yxa-devel@lists.su.se)
+m4_include([m4/erlang-extra.m4])
 REQUIRE_ERLANG_MIN="5.7.2 (Erlang/OTP R13B-1)"
 REQUIRE_ERLANG_MAX="5.9.1 (Erlang/OTP R15B01)"
 AC_CONFIG_SRCDIR([src/incomingproxy.erl])

--- a/src/transportlayer/ssl_util.erl
+++ b/src/transportlayer/ssl_util.erl
@@ -24,7 +24,7 @@
 %%--------------------------------------------------------------------
 %% Include files
 %%--------------------------------------------------------------------
--include("config.hrl").
+-include("../config.hrl").
 -ifdef( HAS_OTP_PUB_KEY_HRL ).
 -include_lib("public_key/include/OTP-PUB-KEY.hrl").
 -define(PKIX_MODULE, 'OTP-PUB-KEY').


### PR DESCRIPTION
configure error:

i'm not good at autoconf stuff.
but following error (during configure) was fixed with this patch.

<pre>
~/hacking/yxa/build$ ../configure
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for a BSD-compatible install... /usr/bin/install -c
checking for erl... /usr/bin/erl
checking for erlc... /usr/bin/erlc
checking for erlc... /usr/bin/erlc
checking for erl... /usr/bin/erl
../configure: line 3148: syntax error near unexpected token `$REQUIRE_ERLANG_MIN,$REQUIRE_ERLANG_MAX'
../configure: line 3148: `              ERLANG_VERSION_CHECK($REQUIRE_ERLANG_MIN,$REQUIRE_ERLANG_MAX)
'</pre>

compilation error(during make):

<pre>
~/hacking/xya/build$ make
......
/usr/bin/erlc +debug_info -o ../../ebin -I../../../src/transportlayer -I../../../src/transportlayer/../include/ -I../../../src/transportlayer/.. -pa ../../ebin ../../../src/transportlayer/ssl_util.erl
../../../src/transportlayer/ssl_util.erl:27: can't find include file "config.hrl"
../../../src/transportlayer/ssl_util.erl:33: can't find include lib "ssl/include/OTP-PKIX.hrl"
../../../src/transportlayer/ssl_util.erl:188: record 'AttributeTypeAndValue' undefined
../../../src/transportlayer/ssl_util.erl:191: record 'AttributeTypeAndValue' undefined
../../../src/transportlayer/ssl_util.erl:195: record 'AttributeTypeAndValue' undefined
../../../src/transportlayer/ssl_util.erl:204: record 'SSLAttributeTypeAndValue' undefined
../../../src/transportlayer/ssl_util.erl:205: record 'SSLAttributeTypeAndValue' undefined
../../../src/transportlayer/ssl_util.erl:247: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:248: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:248: record 'TBSCertificate' undefined
../../../src/transportlayer/ssl_util.erl:288: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:289: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:289: record 'TBSCertificate' undefined
../../../src/transportlayer/ssl_util.erl:299: record 'Extension' undefined
../../../src/transportlayer/ssl_util.erl:301: record 'Extension' undefined
../../../src/transportlayer/ssl_util.erl:311: record 'Extension' undefined
../../../src/transportlayer/ssl_util.erl:312: variable 'Value' is unbound
../../../src/transportlayer/ssl_util.erl:528: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:528: record 'TBSCertificate' undefined
../../../src/transportlayer/ssl_util.erl:532: record 'Certificate' undefined
../../../src/transportlayer/ssl_util.erl:532: record 'TBSCertificate' undefined
../../../src/transportlayer/ssl_util.erl:541: record 'AttributeTypeAndValue' undefined
make[2]: *** [../../ebin/ssl_util.beam] Error 1
make[2]: Leaving directory `/home/namjae/hacking/yxa/build/src/transportlayer'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/namjae/hacking/yxa/build/src'
make: *** [all-recursive] Error 1
</pre>


and my config:

<pre>
~/hacking/yxa$ uname -a
Linux svr.mz 3.5.0-30-generic #51~precise1-Ubuntu SMP Wed May 15 08:48:19 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
~/hacking/yxa$ autoconf --version
autoconf (GNU Autoconf) 2.68
Copyright (C) 2010 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<http://gnu.org/licenses/gpl.html>, <http://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.
</pre>
